### PR TITLE
make a func for creating future tags

### DIFF
--- a/tracing/opentracing/client_interceptors.go
+++ b/tracing/opentracing/client_interceptors.go
@@ -130,6 +130,11 @@ func newClientSpanFromContext(ctx context.Context, tracer opentracing.Tracer, fu
 		grpclog.Printf("grpc_opentracing: failed serializing trace information: %v", err)
 	}
 	ctxWithMetadata := md.ToOutgoing(ctx)
+	// Add oscar-specific tags
+	newOscarTags(clientSpan, fullMethodName)
+	if traceID, ok := md[OscarTraceContextHeaderName]; ok {
+		clientSpan.SetTag(OscarTraceContextHeaderName, traceID)
+	}
 	return opentracing.ContextWithSpan(ctxWithMetadata, clientSpan), clientSpan
 }
 


### PR DESCRIPTION
By default tracing interceptors won't tag some useful info like trace-id or method info.

Make a simple func to add oscar-specific tags.